### PR TITLE
fix: loading /player directly returns 404

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,9 @@ jobs:
       run: dotnet build -c Release
     - name: Publish
       run: dotnet publish -c Release
-    - name: Fix _framework
+    - name: Add 404 page
       run: |
-        mv TubeLess/bin/Release/net8.0/publish/wwwroot/_framework TubeLess/bin/Release/net8.0/publish/wwwroot/framework
-        sed -i 's/_framework/framework/g' TubeLess/bin/Release/net8.0/publish/wwwroot/index.html
-        sed -i 's/_framework/framework/g' TubeLess/bin/Release/net8.0/publish/wwwroot/framework/blazor.webassembly.js
+        cp TubeLess/bin/Release/net8.0/publish/wwwroot/index.html TubeLess/bin/Release/net8.0/publish/wwwroot/404.html
     - name: Setup Pages
       uses: actions/configure-pages@v3
     - name: Upload artifact


### PR DESCRIPTION
Duplicate index.html file as an 404.html in order for GitHub Pages to properly load the web app even when they are not aware of the route.

Additional Changes:
* The GitHub Pages go through Jekyll by default which disables loading of files/folders starting with underscore. Add .nojekyll empty file to prevent that.